### PR TITLE
Feature/existing acm

### DIFF
--- a/modules/cognito/user-pool/main.tf
+++ b/modules/cognito/user-pool/main.tf
@@ -45,14 +45,14 @@ resource aws_route53_record root {
 
 
 locals {
-  acm_arn = var.acm_arn == "" ? module.acm.this_acm_certificate_arn : var.acm_arn
+  acm_arn = var.acm_arn == "" ? module.acm[0].this_acm_certificate_arn : var.acm_arn
 }
 
 module acm {
   source  = "terraform-aws-modules/acm/aws"
   version = "~> v2.0"
 
-  count = var.acm_arn == "" ? 0 : 1 //only create if an existing ACM certificate hasn't been provided
+  count = var.acm_arn == "" ? 1 : 0 //only create if an existing ACM certificate hasn't been provided
 
 
   domain_name          = "auth.${var.domain}"

--- a/modules/cognito/user-pool/main.tf
+++ b/modules/cognito/user-pool/main.tf
@@ -20,7 +20,7 @@ resource aws_cognito_user_pool this {
 
 resource aws_cognito_user_pool_domain this {
   domain          = "auth.${var.domain}"
-  certificate_arn = module.cognito_acm.this_acm_certificate_arn
+  certificate_arn = local.acm_arn
   user_pool_id    = aws_cognito_user_pool.this.id
 }
 
@@ -43,9 +43,17 @@ resource aws_route53_record root {
   records = ["127.0.0.1"]
 }
 
-module cognito_acm {
+
+locals {
+  acm_arn = var.acm_arn == "" ? module.acm.this_acm_certificate_arn : var.acm_arn
+}
+
+module acm {
   source  = "terraform-aws-modules/acm/aws"
   version = "~> v2.0"
+
+  count = var.acm_arn == "" ? 0 : 1 //only create if an existing ACM certificate hasn't been provided
+
 
   domain_name          = "auth.${var.domain}"
   zone_id              = var.zone_id

--- a/modules/cognito/user-pool/variables.tf
+++ b/modules/cognito/user-pool/variables.tf
@@ -17,7 +17,7 @@ variable tags {
   default     = {}
 }
 
-variable cognito_acm_arn {
+variable acm_arn {
   type = string
   description = "The ARN of an ACM certificate to attach to the Cognito App Domain (must be in us-east-1)"
   default = ""

--- a/modules/cognito/user-pool/variables.tf
+++ b/modules/cognito/user-pool/variables.tf
@@ -17,6 +17,11 @@ variable tags {
   default     = {}
 }
 
+variable cognito_acm_arn {
+  type = string
+  description = "The ARN of an ACM certificate to attach to the Cognito App Domain (must be in us-east-1)"
+  default = ""
+}
 variable invite_template {
   type        = map(string)
   description = "A template for the invite email with credentials"


### PR DESCRIPTION
acm cert creation is now optional. Existing ARN can be passed as a variable