### PR TITLE
Hotfix/eks cluster

### DIFF
--- a/examples/common/main.tf
+++ b/examples/common/main.tf
@@ -69,7 +69,7 @@ module "kubernetes" {
 
   on_demand_gpu_instance_type = "g4dn.xlarge"
 }
-#
+
 module "system" {
   depends_on = [module.network.vpc_id, module.kubernetes.cluster_name]
   source            = "../../modules/system"
@@ -84,7 +84,7 @@ module "system" {
   mainzoneid         = var.mainzoneid
   cert_manager_email = var.cert_manager_email
   cluster_oidc_url   = module.kubernetes.cluster_oidc_url
-  cluster_oidc_arn   = module.kubernetes.cluster_output.oidc_provider_arn
+  cluster_oidc_arn   = module.kubernetes.oidc_provider_arn
   cluster_roles      = []
 }
 #

--- a/modules/kubeflow-operator/main.tf
+++ b/modules/kubeflow-operator/main.tf
@@ -1,13 +1,3 @@
-
-
-
-
-
-
-data "aws_eks_cluster" "this" {
-  name = var.cluster_name
-}
-
 data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}

--- a/modules/kubernetes/outputs.tf
+++ b/modules/kubernetes/outputs.tf
@@ -13,13 +13,18 @@ output "cluster_oidc_url" {
   description = "Oidc issuer url for EKS cluster"
 }
 
-output "cluster_output" {
-  value = {
-    "cluster_oidc_issuer_url" = module.eks.cluster_oidc_issuer_url,
-    "oidc_provider_arn"       = module.eks.oidc_provider_arn,
-    "cluster_id"              = module.eks.cluster_id
-  }
+output "oidc_provider_arn" {
+  value       = module.eks.oidc_provider_arn
+  description = "oidc provider url for EKS cluster"
 }
+
+# output "cluster_output" {
+#   value = {
+#     "cluster_oidc_issuer_url" = module.eks.cluster_oidc_issuer_url,
+#     "oidc_provider_arn"       = module.eks.oidc_provider_arn,
+#     "cluster_id"              = module.eks.cluster_id
+#   }
+# }
 
 output "this" {
   value       = module.eks

--- a/modules/mlflow/main.tf
+++ b/modules/mlflow/main.tf
@@ -1,9 +1,3 @@
-
-
-data "aws_eks_cluster" "this" {
-  name = var.cluster_name
-}
-
 data "aws_caller_identity" "current" {}
 
 data "aws_region" "current" {}

--- a/modules/system/external-secrets/iam.tf
+++ b/modules/system/external-secrets/iam.tf
@@ -1,14 +1,10 @@
-module "kubernetes" {
-  source = "./../../kubernetes"
-}
-
 module "iam_assumable_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "~> v3.6.0"
   count                         = local.create_role ? 1 : 0
   create_role                   = true
   role_name                     = "${local.cluster_name}_external-secrets"
-  provider_url                  = replace(module.kubernetes.cluster_oidc_url, "https://", "")
+  provider_url                  = replace(data.terraform_remote_state.kubernetes.cluster_oidc_url, "https://", "")
   role_policy_arns              = local.role_policy_arns
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.namespace}:external_secrets"] //TODO dynamically get service account name and set it here. Currently all service accounts in kube-system will be able to assume this role
   tags                          = var.tags

--- a/modules/system/external-secrets/iam.tf
+++ b/modules/system/external-secrets/iam.tf
@@ -4,7 +4,7 @@ module "iam_assumable_role" {
   count                         = local.create_role ? 1 : 0
   create_role                   = true
   role_name                     = "${local.cluster_name}_external-secrets"
-  provider_url                  = replace("${module.kubernetes.cluster_oidc_url}", "https://", "")
+  provider_url                  = replace(module.kubernetes.cluster_oidc_url, "https://", "")
   role_policy_arns              = local.role_policy_arns
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.namespace}:external_secrets"] //TODO dynamically get service account name and set it here. Currently all service accounts in kube-system will be able to assume this role
   tags                          = var.tags

--- a/modules/system/external-secrets/iam.tf
+++ b/modules/system/external-secrets/iam.tf
@@ -4,7 +4,7 @@ module "iam_assumable_role" {
   count                         = local.create_role ? 1 : 0
   create_role                   = true
   role_name                     = "${local.cluster_name}_external-secrets"
-  provider_url                  = replace(${module.kubernetes.cluster_oidc_url}, "https://", "")
+  provider_url                  = replace("${module.kubernetes.cluster_oidc_url}", "https://", "")
   role_policy_arns              = local.role_policy_arns
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.namespace}:external_secrets"] //TODO dynamically get service account name and set it here. Currently all service accounts in kube-system will be able to assume this role
   tags                          = var.tags

--- a/modules/system/external-secrets/iam.tf
+++ b/modules/system/external-secrets/iam.tf
@@ -1,14 +1,10 @@
-data "aws_eks_cluster" "this" {
-  name = var.cluster_name
-}
-
 module "iam_assumable_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "~> v3.6.0"
   count                         = local.create_role ? 1 : 0
   create_role                   = true
   role_name                     = "${local.cluster_name}_external-secrets"
-  provider_url                  = replace(data.aws_eks_cluster.this.identity.0.oidc.0.issuer, "https://", "")
+  provider_url                  = replace(local.cluster_oidc_url, "https://", "")
   role_policy_arns              = local.role_policy_arns
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.namespace}:external_secrets"] //TODO dynamically get service account name and set it here. Currently all service accounts in kube-system will be able to assume this role
   tags                          = var.tags

--- a/modules/system/external-secrets/iam.tf
+++ b/modules/system/external-secrets/iam.tf
@@ -4,7 +4,7 @@ module "iam_assumable_role" {
   count                         = local.create_role ? 1 : 0
   create_role                   = true
   role_name                     = "${local.cluster_name}_external-secrets"
-  provider_url                  = replace(data.terraform_remote_state.kubernetes.cluster_oidc_url, "https://", "")
+  provider_url                  = replace(var.cluster_oidc_url, "https://", "")
   role_policy_arns              = local.role_policy_arns
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.namespace}:external_secrets"] //TODO dynamically get service account name and set it here. Currently all service accounts in kube-system will be able to assume this role
   tags                          = var.tags

--- a/modules/system/external-secrets/iam.tf
+++ b/modules/system/external-secrets/iam.tf
@@ -4,7 +4,7 @@ module "iam_assumable_role" {
   count                         = local.create_role ? 1 : 0
   create_role                   = true
   role_name                     = "${local.cluster_name}_external-secrets"
-  provider_url                  = replace(local.cluster_oidc_url, "https://", "")
+  provider_url                  = replace(${module.kubernetes.cluster_oidc_url}, "https://", "")
   role_policy_arns              = local.role_policy_arns
   oidc_fully_qualified_subjects = ["system:serviceaccount:${var.namespace}:external_secrets"] //TODO dynamically get service account name and set it here. Currently all service accounts in kube-system will be able to assume this role
   tags                          = var.tags

--- a/modules/system/external-secrets/iam.tf
+++ b/modules/system/external-secrets/iam.tf
@@ -1,3 +1,7 @@
+module "kubernetes" {
+  source = "./../../kubernetes"
+}
+
 module "iam_assumable_role" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
   version                       = "~> v3.6.0"

--- a/modules/system/external-secrets/locals.tf
+++ b/modules/system/external-secrets/locals.tf
@@ -2,6 +2,7 @@ locals {
   module_name         = basename(abspath(path.module))
   app_name            = "external-secrets"
   cluster_name        = var.cluster_name
+  cluster_oidc_url    = var.cluster_oidc_url
   aws_region          = var.aws_region == "" ? data.aws_region.current.name : var.aws_region
 
   create_role = var.chart_values != "" || var.aws_assume_role_arn != "" ? false : true

--- a/modules/system/external-secrets/locals.tf
+++ b/modules/system/external-secrets/locals.tf
@@ -2,7 +2,6 @@ locals {
   module_name         = basename(abspath(path.module))
   app_name            = "external-secrets"
   cluster_name        = var.cluster_name
-  cluster_oidc_url    = var.cluster_oidc_url
   aws_region          = var.aws_region == "" ? data.aws_region.current.name : var.aws_region
 
   create_role = var.chart_values != "" || var.aws_assume_role_arn != "" ? false : true

--- a/modules/system/external-secrets/variables.tf
+++ b/modules/system/external-secrets/variables.tf
@@ -27,6 +27,11 @@ variable "cluster_name" {
   description = "Name of the EKS cluster"
 }
 
+variable "cluster_oidc_url" {
+  type        = string
+  description = "oidc issuer url of the eks cluster"
+}
+
 variable "chart_repository" {
   type    = string
   description = "A chart repository"

--- a/modules/system/external-secrets/variables.tf
+++ b/modules/system/external-secrets/variables.tf
@@ -27,10 +27,10 @@ variable "cluster_name" {
   description = "Name of the EKS cluster"
 }
 
-# variable "cluster_oidc_url" {
-#   type        = string
-#   description = "oidc issuer url of the eks cluster"
-# }
+variable "cluster_oidc_url" {
+  type        = string
+  description = "oidc issuer url of the eks cluster"
+}
 
 variable "chart_repository" {
   type    = string

--- a/modules/system/external-secrets/variables.tf
+++ b/modules/system/external-secrets/variables.tf
@@ -27,10 +27,10 @@ variable "cluster_name" {
   description = "Name of the EKS cluster"
 }
 
-variable "cluster_oidc_url" {
-  type        = string
-  description = "oidc issuer url of the eks cluster"
-}
+# variable "cluster_oidc_url" {
+#   type        = string
+#   description = "oidc issuer url of the eks cluster"
+# }
 
 variable "chart_repository" {
   type    = string


### PR DESCRIPTION
In module `system/external-secrets`, this block

```
data "aws_eks_cluster" "this" {
  name = var.cluster_name
}
```
was used to retrieve the cluster name. In case we build the infrastructure from scratch, this will throw an error because the cluster has not been build yet.

The changes in this PR allow for receiving the cluster name as input variable instead of querying it using the data blocks.